### PR TITLE
Fix implementations of Array#sort and #sortOn and make classes proper instances of AXObject

### DIFF
--- a/src/avm2/abc/lazy.ts
+++ b/src/avm2/abc/lazy.ts
@@ -619,7 +619,7 @@ module Shumway.AVMX {
     }
 
     public getPublicMangledName(): any {
-      return Multiname.getPublicMangledName(this.name);
+      return "$Bg" + this.name;
     }
 
     private _nameToString(): string {
@@ -713,7 +713,7 @@ module Shumway.AVMX {
     }
 
     public static getPublicMangledName(value: any): any {
-      return "$" + Namespace.PUBLIC.getMangledName() + value;
+      return "$Bg" + value;
     }
 
     public static getMangledName(value: any): any {

--- a/src/avm2/errors.ts
+++ b/src/avm2/errors.ts
@@ -81,7 +81,7 @@ module Shumway.AVM2 {
   //  NumberOutOfRangeError                : {code: 1061, message: "The value %1 cannot be converted to %2 without losing precision."},
     WrongArgumentCountError              : {code: 1063, message: "Argument count mismatch on %1. Expected %2, got %3."},
   //  CannotCallMethodAsConstructor        : {code: 1064, message: "Cannot call method %1 as constructor."},
-  //  UndefinedVarError                    : {code: 1065, message: "Variable %1 is not defined."},
+    UndefinedVarError                    : {code: 1065, message: "Variable %1 is not defined."},
   //  FunctionConstructorError             : {code: 1066, message: "The form function('function body') is not supported."},
   //  IllegalNativeMethodBodyError         : {code: 1067, message: "Native method %1 has illegal method body."},
   //  CannotMergeTypesError                : {code: 1068, message: "%1 and %2 cannot be reconciled."},

--- a/src/avm2/int.ts
+++ b/src/avm2/int.ts
@@ -411,7 +411,7 @@ module Shumway.AVMX {
           //  stack[stack.length - 1] = applyType(method, stack[stack.length - 1], args);
           //  break;
           case Bytecode.NEWOBJECT:
-            object = securityDomain.AXObject.axConstruct();
+            object = Object.create(securityDomain.AXObject.tPrototype);
             argCount = u30();
             for (var i = 0; i < argCount; i++) {
               value = stack.pop();
@@ -423,7 +423,7 @@ module Shumway.AVMX {
             object = [];
             popManyInto(stack, u30(), args);
             object.push.apply(object, args);
-            stack.push(securityDomain.box(object));
+            stack.push(securityDomain.AXArray.axBox(object));
             break;
           case Bytecode.NEWACTIVATION:
             stack.push(securityDomain.createActivation(methodInfo));

--- a/src/avm2/int.ts
+++ b/src/avm2/int.ts
@@ -343,6 +343,9 @@ module Shumway.AVMX {
           case Bytecode.PUSHSCOPE:
             scope.push(securityDomain.box(stack.pop()), false);
             break;
+          case Bytecode.PUSHWITH:
+            scope.push(securityDomain.box(stack.pop()), true);
+            break;
           case Bytecode.NEWFUNCTION:
             stack.push(securityDomain.createFunction(abc.getMethodInfo(u30()), scope.topScope(), true));
             break;

--- a/src/avm2/nat.ts
+++ b/src/avm2/nat.ts
@@ -203,7 +203,8 @@ module Shumway.AVMX.AS {
     }
 
     static _init() {
-      this.dPrototype.axSetPublicProperty("hasOwnProperty", new this.securityDomain.AXFunction(ASObject.prototype.native_hasOwnProperty));
+      this.dPrototype.axSetPublicProperty("hasOwnProperty",
+                                          this.securityDomain.AXFunction.axBox(ASObject.prototype.native_hasOwnProperty));
       //this.dPrototype.axSetPublicProperty("propertyIsEnumerable", ASObject.prototype.native_propertyIsEnumerable);
       //this.dPrototype.axSetPublicProperty("setPropertyIsEnumerable", ASObject.prototype.setPropertyIsEnumerable);
       //this.dPrototype.axSetPublicProperty("isPrototypeOf", ASObject.prototype.native_isPrototypeOf);
@@ -1304,10 +1305,10 @@ module Shumway.AVMX.AS {
           value.push(a);
         }
       }
-      return new this.securityDomain.AXArray(value);
+      return this.securityDomain.AXArray.axBox(value);
     }
     slice(startIndex: number, endIndex: number) {
-      return new this.securityDomain.AXArray(this.value.slice(startIndex, endIndex));
+      return this.securityDomain.AXArray.axBox(this.value.slice(startIndex, endIndex));
     }
     join(sep: string) {
       return this.value.join(sep);
@@ -1337,7 +1338,7 @@ module Shumway.AVMX.AS {
       return this.value.forEach(callbackfn.value, thisArg);
     }
     map(callbackfn: {value}, thisArg?) {
-      return new this.securityDomain.AXArray(this.value.map(callbackfn.value, thisArg));
+      return this.securityDomain.AXArray.axBox(this.value.map(callbackfn.value, thisArg));
     }
     filter(callbackfn: {value: Function}, thisArg?) {
       var result = [];
@@ -1347,11 +1348,11 @@ module Shumway.AVMX.AS {
           result.push(o[i]);
         }
       }
-      return new this.securityDomain.AXArray(result);
+      return this.securityDomain.AXArray.axBox(result);
     }
 
     toLocaleString(): string {
-      var value = this.securityDomain.AXArray.coerce(this).value;
+      var value = this.securityDomain.AXArray.axCoerce(this).value;
 
       var out: string = "";
       for (var i = 0, n = value.length; i < n; i++) {
@@ -1371,7 +1372,7 @@ module Shumway.AVMX.AS {
       if (arguments.length === 0) {
         return undefined;
       }
-      return new this.securityDomain.AXArray(o.splice.apply(o, arguments));
+      return this.securityDomain.AXArray.axBox(o.splice.apply(o, arguments));
     }
 
     sort(): any {
@@ -1382,7 +1383,7 @@ module Shumway.AVMX.AS {
       }
       var compareFunction;
       var options = 0;
-      if (arguments[0] instanceof this.securityDomain.AXFunction) {
+      if (this.securityDomain.AXFunction.axIsInstanceOf(arguments[0])) {
         compareFunction = arguments[0].value;
       } else if (isNumber(arguments[0])) {
         options = arguments[0];

--- a/src/avm2/nat.ts
+++ b/src/avm2/nat.ts
@@ -1375,56 +1375,86 @@ module Shumway.AVMX.AS {
     }
 
     sort(): any {
-      var o = <any>this;
+      var o = this.value;
       if (arguments.length === 0) {
-        return o.sort();
+        o.sort();
+        return this;
       }
-      var compareFunction, options = 0;
-      if (arguments[0] instanceof Function) {
-        compareFunction = arguments[0];
+      var compareFunction;
+      var options = 0;
+      if (arguments[0] instanceof this.securityDomain.AXFunction) {
+        compareFunction = arguments[0].value;
       } else if (isNumber(arguments[0])) {
         options = arguments[0];
       }
       if (isNumber(arguments[1])) {
         options = arguments[1];
       }
+      if (!options) {
+        // Just passing compareFunction is ok because `undefined` is treated as not passed in JS.
+        o.sort(compareFunction);
+        return this;
+      }
+      if (!compareFunction) {
+        compareFunction = axDefaultCompareFunction;
+      }
+      var sortOrder = options & SORT.DESCENDING ? -1 : 1;
       o.sort(function (a, b) {
-        return asCompare(a, b, options, compareFunction);
+        return axCompare(a, b, options, sortOrder, compareFunction);
       });
-      return o;
+      return this;
     }
 
     sortOn(names: any, options: any): any {
-      var o = <any>this;
+      if (arguments.length === 0) {
+        throwError("ArgumentError", AVM2.Errors.WrongArgumentCountError,
+                   "Array/http://adobe.com/AS3/2006/builtin::sortOn()", "1", "0");
+      }
+      // The following oddities in how the arguments are used are gleaned from Tamarin, so hush.
+      var o = this.value;
+      // The options we'll end up using.
+      var optionsList: number[] = [];
       if (isString(names)) {
-        names = [names];
-      }
-      if (isNullOrUndefined(options)) {
-        options = [];
-      } else if (isNumber(options)) {
-        options = [options];
-      }
-      for (var i = names.length - 1; i >= 0; i--) {
-        var key = Multiname.getPublicMangledName(names[i]);
-        if (ASArray.CACHE_NUMERIC_COMPARATORS && options[i] & SORT.NUMERIC) {
-          var str = "var x = +(a." + key + "), y = +(b." + key + ");";
-          if (options[i] & SORT.DESCENDING) {
-            str += "return x < y ? 1 : (x > y ? -1 : 0);";
-          } else {
-            str += "return x < y ? -1 : (x > y ? 1 : 0);";
-          }
-          var numericComparator = ASArray.numericComparatorCache[str];
-          if (!numericComparator) {
-            numericComparator = ASArray.numericComparatorCache[str] = new Function("a", "b", str);
-          }
-          o.sort(numericComparator);
-        } else {
-          o.sort(function (a, b) {
-            return asCompare(a[key], b[key], options[i] | 0);
-          });
+        names = [Multiname.getPublicMangledName(names)];
+        // If the name is a string, coerce `options` to int.
+        optionsList = [options | 0];
+      } else if (names && Array.isArray(names.value)) {
+        names = names.value;
+        for (var i = 0; i < names.length; i++) {
+          names[i] = Multiname.getPublicMangledName(names[i]);
         }
+        if (options && Array.isArray(options.value)) {
+          options = options.value;
+          // Use the options Array only if it's the same length as names.
+          if (options.length === names.length) {
+            for (var i = 0; i < options.length; i++) {
+              optionsList[i] = options[i] | 0;
+            }
+            // Otherwise, use 0 for all options.
+          } else {
+            for (var i = 0; i < names.length; i++) {
+              optionsList[i] = 0;
+            }
+          }
+        } else {
+          var optionsVal = options | 0;
+          for (var i = 0; i < names.length; i++) {
+            optionsList[i] = optionsVal;
+          }
+        }
+      } else {
+        // Not supplying either a String or an Array means nothing is sorted on.
+        return this;
       }
-      return o;
+      release || assert(optionsList.length === names.length);
+      // For use with uniqueSort and returnIndexedArray once we support them.
+      var optionsVal: number = optionsList[0];
+      release || Shumway.Debug.assertNotImplemented(!(optionsVal & SORT.UNIQUESORT), "UNIQUESORT");
+      release || Shumway.Debug.assertNotImplemented(!(optionsVal & SORT.RETURNINDEXEDARRAY),
+                                                    "RETURNINDEXEDARRAY");
+
+      o.sort((a, b) => axCompareFields(a, b, names, optionsList));
+      return this;
     }
 
     get length(): number {
@@ -1530,8 +1560,8 @@ module Shumway.AVMX.AS {
   //
   //  static classInitializer: any = function() {
   //    defineNonEnumerableProperty(this, '$Bglength', 1);
-  //    defineNonEnumerableProperty(this.dynamicPrototype, '$Bgname', 'Error');
-  //    defineNonEnumerableProperty(this.dynamicPrototype, '$Bgmessage', 'Error');
+  // defineNonEnumerableProperty(this.dynamicPrototype, '$Bgname', 'Error');
+  // defineNonEnumerableProperty(this.dynamicPrototype, '$Bgmessage', 'Error');
   //    defineNonEnumerableProperty(this.dynamicPrototype, '$BgtoString', this.prototype.toString);
   //  }
   //

--- a/src/avm2/run.ts
+++ b/src/avm2/run.ts
@@ -115,29 +115,53 @@ module Shumway.AVMX {
     return !!x;
   }
 
-  export function asDefaultCompareFunction(a, b) {
+  export function axDefaultCompareFunction(a, b) {
     return String(a).localeCompare(String(b));
   }
 
-  export function asCompare(a: any, b: any, options: SORT, compareFunction?) {
+  export function axCompare(a: any, b: any, options: SORT, sortOrder: number,
+                            compareFunction: (a, b) => number) {
     release || Shumway.Debug.assertNotImplemented(!(options & SORT.UNIQUESORT), "UNIQUESORT");
-    release || Shumway.Debug.assertNotImplemented(!(options & SORT.RETURNINDEXEDARRAY), "RETURNINDEXEDARRAY");
+    release || Shumway.Debug.assertNotImplemented(!(options & SORT.RETURNINDEXEDARRAY),
+                                                  "RETURNINDEXEDARRAY");
     var result = 0;
-    if (!compareFunction) {
-      compareFunction = asDefaultCompareFunction;
-    }
     if (options & SORT.CASEINSENSITIVE) {
       a = String(a).toLowerCase();
       b = String(b).toLowerCase();
     }
     if (options & SORT.NUMERIC) {
-      a = toNumber(a);
-      b = toNumber(b);
+      a = +a;
+      b = +b;
       result = a < b ? -1 : (a > b ? 1 : 0);
     } else {
       result = compareFunction(a, b);
     }
-    if (options & SORT.DESCENDING) {
+    return result * sortOrder;
+  }
+
+  export function axCompareFields(objA: any, objB: any, names: string[], optionsList: SORT[]) {
+    release || assert(names.length === optionsList.length);
+    release || assert(names.length > 0);
+    var result = 0;
+    var i;
+    for (i = 0; i < names.length && result === 0; i++) {
+      var name = names[i];
+      var a = objA[name];
+      var b = objB[name];
+      var options = optionsList[i];
+      if (options & SORT.CASEINSENSITIVE) {
+        a = String(a).toLowerCase();
+        b = String(b).toLowerCase();
+      }
+      if (options & SORT.NUMERIC) {
+        a = +a;
+        b = +b;
+        result = a < b ? -1 : (a > b ? 1 : 0);
+      } else {
+        result = String(a).localeCompare(String(b));
+      }
+    }
+    if (optionsList[i - 1] & SORT.DESCENDING) {
       result *= -1;
     }
     return result;
@@ -905,6 +929,8 @@ module Shumway.AVMX {
       P(AXArray.dPrototype, "forEach", Ap.forEach);
       P(AXArray.dPrototype, "map", Ap.map);
       P(AXArray.dPrototype, "filter", Ap.filter);
+      P(AXArray.dPrototype, "sort", Ap.sort);
+      P(AXArray.dPrototype, "sortOn", Ap.sortOn);
 
       D(AXArray.prototype, "axGetProperty", axArrayGetProperty);
       D(AXArray.prototype, "axSetProperty", axArraySetProperty);


### PR DESCRIPTION
At least as far as I can test them: `Array.NUMERIC` & co seem not to resolve properly right now.

So this doesn't currently fix new tests, but the `sort` and `sort-1` tests pass partially instead of throwing immediately.