### PR TITLE
Improve handling of Namespaces

### DIFF
--- a/src/avm2/abc/lazy.ts
+++ b/src/avm2/abc/lazy.ts
@@ -87,6 +87,15 @@ module Shumway.AVMX {
     Metadata           = 0x04
   }
 
+  export enum NamespaceType {
+    Public          = 0,
+    Protected       = 1,
+    PackageInternal = 2,
+    Private         = 3,
+    Explicit        = 4,
+    StaticProtected = 5
+  }
+
   export enum SORT {
     CASEINSENSITIVE = 1,
     DESCENDING = 2,
@@ -174,9 +183,10 @@ module Shumway.AVMX {
         }
         var traitMn = <Multiname>trait.name;
         if (traitMn.name === mnName) {
-          var nsName = traitMn.namespaces[0].name;
+          var namespace = traitMn.namespaces[0];
+          var nsName = namespace.uri;
           for (var j = 0; j < nss.length; j++) {
-            if (nsName === nss[j].name) {
+            if (nsName === nss[j].uri && namespace.type === nss[j].type) {
               return i;
             }
           }
@@ -710,7 +720,7 @@ module Shumway.AVMX {
       if (this.isRuntimeNamespace() || this.namespaces.length > 1) {
         return false;
       }
-      return this.namespaces[0].name === "";
+      return this.namespaces[0].uri === "";
 
       // x.* has the same meaning as x.*::*, so look for the former case and give
       // it the same meaning of the latter.
@@ -734,15 +744,13 @@ module Shumway.AVMX {
       return false;
     }
 
-    public static getPublicMangledName(value: any): any {
-      return "$Bg" + value;
+    public static getPublicMangledName(name: string): any {
+      return "$Bg" + name;
     }
 
-    public static getMangledName(value: any): any {
-      if (value instanceof Multiname) {
-        return value.getMangledName();
-      }
-      return Multiname.getPublicMangledName(value);
+    public static getMangledName(name: Multiname): any {
+      release || assert(name instanceof Multiname);
+      return name.getMangledName();
     }
 
     public static isPublicQualifiedName(value: any): boolean {
@@ -751,31 +759,35 @@ module Shumway.AVMX {
     }
   }
 
+  // Used in _hashNamespace so we don't need to allocate a new buffer each time.
+  var namespaceHashingBuffer = new Int32Array(100);
+
   export class Namespace {
     public prefix: string = "";
     private _mangledName: string = null;
-    constructor(public abc: ABCFile, public kind: CONSTANT, public name: string) {
-      assert (kind !== undefined);
+    constructor(public abc: ABCFile, public type: NamespaceType, public uri: string) {
+      assert (type !== undefined);
     }
 
     toString() {
-      return CONSTANT[this.kind] + (this.name !== "" ? ":" + this.name : "");
+      return NamespaceType[this.type] + (this.uri !== "" ? ":" + this.uri : "");
     }
 
     private static _knownNames = [
       ""
     ];
 
-    private static _hashNamespace(kind: CONSTANT, name: string, prefix: string) {
-      var index = Namespace._knownNames.indexOf(name);
+    private static _hashNamespace(type: NamespaceType, uri: string, prefix: string) {
+      var index = Namespace._knownNames.indexOf(uri);
       if (index >= 0) {
-        return kind << 2 | index;
+        return type << 2 | index;
       }
-      var data = new Int32Array(1 + name.length + prefix.length);
+      var length = 1 + uri.length + prefix.length;
+      var data = length < 101 ? namespaceHashingBuffer : new Int32Array(length);
       var j = 0;
-      data[j++] = kind;
-      for (var i = 0; i < name.length; i++) {
-        data[j++] = name.charCodeAt(i);
+      data[j++] = type;
+      for (var i = 0; i < uri.length; i++) {
+        data[j++] = uri.charCodeAt(i);
       }
       for (var i = 0; i < prefix.length; i++) {
         data[j++] = prefix.charCodeAt(i);
@@ -787,15 +799,20 @@ module Shumway.AVMX {
       if (this._mangledName !== null) {
         return this._mangledName;
       }
-      return this._mangledName = Shumway.StringUtilities.variableLengthEncodeInt32(Namespace._hashNamespace(this.kind, this.name, this.prefix))
+      if (this.type === NamespaceType.Public) {
+        return this._mangledName = 'Bg';
+      }
+      var nsHash = Namespace._hashNamespace(this.type, this.uri, this.prefix);
+      return this._mangledName = Shumway.StringUtilities.variableLengthEncodeInt32(nsHash);
     }
 
-    public static PUBLIC = new Namespace(null, CONSTANT.Namespace, "");
-    public static PROTECTED = new Namespace(null, CONSTANT.ProtectedNamespace, "");
-    public static PROXY = new Namespace(null, CONSTANT.Namespace, "http://www.adobe.com/2006/actionscript/flash/proxy");
-    public static VECTOR = new Namespace(null, CONSTANT.Namespace, "__AS3__.vec");
-    public static VECTOR_PACKAGE = new Namespace(null, CONSTANT.PackageInternalNs, "__AS3__.vec");
-    public static BUILTIN = new Namespace(null, CONSTANT.PrivateNs, "builtin.as$0");
+    public static PUBLIC = new Namespace(null, NamespaceType.Public, "");
+    public static PROTECTED = new Namespace(null, NamespaceType.Protected, "");
+    public static STATIC_PROTECTED = new Namespace(null, NamespaceType.StaticProtected, "");
+    public static PROXY = new Namespace(null, NamespaceType.Public, "http://www.adobe.com/2006/actionscript/flash/proxy");
+    public static VECTOR = new Namespace(null, NamespaceType.Public, "__AS3__.vec");
+    public static VECTOR_PACKAGE = new Namespace(null, NamespaceType.PackageInternal, "__AS3__.vec");
+    public static BUILTIN = new Namespace(null, NamespaceType.Private, "builtin.as$0");
   }
 
   export class ABCFile {
@@ -970,7 +987,8 @@ module Shumway.AVMX {
         case CONSTANT.TypeName:
           s.readU32();
           var typeParameterCount = s.readU32();
-          release || assert(typeParameterCount === 1); // This is probably the number of type parameters.
+          release || assert(typeParameterCount === 1); // This is probably the number of type
+                                                       // parameters.
           s.readU32();
           break;
         default:
@@ -1123,13 +1141,48 @@ module Shumway.AVMX {
         return null;
       }
       var ns = this._namespaces[i];
-      if (ns === undefined) {
-        var s = this._stream;
-        s.seek(this._namespaceOffsets[i]);
-        var kind = s.readU8();
-        var name = this.getString(s.readU30());
-        ns = this._namespaces[i] = new Namespace(this, kind, name);
+      if (ns !== undefined) {
+        return ns;
       }
+      var s = this._stream;
+      s.seek(this._namespaceOffsets[i]);
+      var kind = s.readU8();
+      var uriIndex = s.readU30();
+      var uri = uriIndex ? this.getString(uriIndex) : undefined;
+      var type: NamespaceType;
+      switch (kind) {
+        case CONSTANT.Namespace:
+        case CONSTANT.PackageNamespace:
+          type = NamespaceType.Public;
+          break;
+        case CONSTANT.PackageInternalNs:
+          type = NamespaceType.PackageInternal;
+          break;
+        case CONSTANT.ProtectedNamespace:
+          type = NamespaceType.Protected;
+          break;
+        case CONSTANT.ExplicitNamespace:
+          type = NamespaceType.Explicit;
+          break;
+        case CONSTANT.StaticProtectedNs:
+          type = NamespaceType.StaticProtected;
+          break;
+        case CONSTANT.PrivateNs:
+          type = NamespaceType.Private;
+          break;
+        default:
+          throwError("VerifierError", Errors.CpoolEntryWrongTypeError, i);
+      }
+      if (uri && type !== NamespaceType.Private) {
+        // TODO: deal with API versions here. Those are suffixed to the uri. We used to
+        // just strip them out, but we also had an assert against them occurring at all,
+        // so it might be the case that we don't even need to do anything at all.
+      } else if (uri === undefined) {
+        // Only private namespaces gets the empty string instead of undefined. A comment
+        // in Tamarin source code indicates this might not be intentional, but oh well.
+        uri = '';
+      }
+      ns = this._namespaces[i] = new Namespace(this, type, uri);
       return ns;
     }
 

--- a/src/avm2/abc/lazy.ts
+++ b/src/avm2/abc/lazy.ts
@@ -127,8 +127,9 @@ module Shumway.AVMX {
   }
 
   export class Traits {
-    private _nextSlotID: number = 1;
     public slots: SlotTraitInfo [] = null;
+    private _nextSlotID: number = 1;
+    private _resolved = false;
     constructor(
       public traits: TraitInfo []
     ) {
@@ -136,9 +137,13 @@ module Shumway.AVMX {
     }
 
     resolve() {
+      if (this._resolved) {
+        return;
+      }
       for (var i = 0; i < this.traits.length; i++) {
         this.traits[i].resolve();
       }
+      this._resolved = true;
     }
 
     attachHolder(holder: Info) {
@@ -158,6 +163,7 @@ module Shumway.AVMX {
      * if you don't care about the kind.
      */
     indexOf(mn: Multiname, kind: TRAIT): number {
+      release || assert(this._resolved);
       var mnName = mn.name;
       var nss = mn.namespaces;
       var traits = this.traits;
@@ -212,6 +218,7 @@ module Shumway.AVMX {
     }
 
     getSlot(i: number): TraitInfo {
+      release || assert(this._resolved);
       if (this.slots === null) {
         var slots = this.slots = [];
         for (var j = 0; j < this.traits.length; j++) {

--- a/src/avm2/errors.ts
+++ b/src/avm2/errors.ts
@@ -53,7 +53,7 @@ module Shumway.AVM2 {
   //  StackDepthUnbalancedError            : {code: 1030, message: "Stack depth is unbalanced. %1 != %2."},
   //  ScopeDepthUnbalancedError            : {code: 1031, message: "Scope depth is unbalanced. %1 != %2."},
   //  CpoolIndexRangeError                 : {code: 1032, message: "Cpool index %1 is out of range %2."},
-  //  CpoolEntryWrongTypeError             : {code: 1033, message: "Cpool entry %1 is wrong type."},
+    CpoolEntryWrongTypeError             : {code: 1033, message: "Cpool entry %1 is wrong type."},
     CheckTypeFailedError                 : {code: 1034, message: "Type Coercion failed: cannot convert %1 to %2."},
   //  IllegalSuperCallError                : {code: 1035, message: "Illegal super expression found in method %1."},
   //  CannotAssignToMethodError            : {code: 1037, message: "Cannot assign to a method %1 on %2."},

--- a/src/avm2/nat.ts
+++ b/src/avm2/nat.ts
@@ -744,7 +744,7 @@ module Shumway.AVMX.AS {
           return false;
         }
         release || assert(value.class.implementedInterfaces, "No 'implementedInterfaces' map found on class " + value.class);
-        var qualifiedName = Multiname.getMangledName(this.classInfo.instanceInfo.name);
+        var qualifiedName = Multiname.getMangledName(this.classInfo.instanceInfo.getName());
         return value.class.implementedInterfaces[qualifiedName] !== undefined;
       }
 
@@ -776,7 +776,7 @@ module Shumway.AVMX.AS {
 
     public getQualifiedClassName(): string {
       var name = this.classInfo.instanceInfo.getName();
-      var namespaceName = name.namespaces[0].name;
+      var namespaceName = name.namespaces[0].uri;
       if (namespaceName) {
         return namespaceName + "::" + name.name;
       }
@@ -910,8 +910,6 @@ module Shumway.AVMX.AS {
     public static instanceConstructor: any = Function;
     public static classBindings: ClassBindings;
     public static instanceBindings: InstanceBindings;
-    public static staticNatives: any [] = [Function];
-    public static instanceNatives: any [] = [Function.prototype];
 
     static classInitializer: any = function() {
       var proto: any = ASFunction.dynamicPrototype;
@@ -928,6 +926,8 @@ module Shumway.AVMX.AS {
       release || assertUnreachable('ASFunction references must be delegated to Function');
     }
 
+    private value: Function;
+
     get native_prototype(): Object {
       var self: Function = <any>this;
       return self.prototype;
@@ -941,6 +941,14 @@ module Shumway.AVMX.AS {
     get length(): number {
       assert (false, "Fix me.");
       return 0;
+    }
+
+    call(self: any, ...args: any[]): any {
+      return this.value.apply(self, args);
+    }
+
+    apply(self: any, args?: any): any {
+      return this.value.apply(self, args);
     }
 
     asCall: (self?, args?: any) => any;

--- a/src/avm2/run.ts
+++ b/src/avm2/run.ts
@@ -324,14 +324,14 @@ module Shumway.AVMX {
   }
 
   function axHasPropertyInternal(mn: Multiname): boolean {
-    return this.traits.indexOf(mn) >= 0;
+    return this.traits.indexOf(mn, -1) >= 0;
   }
 
   function axResolveMultiname(mn: Multiname): any {
     if (mn.isRuntimeName() && isNumeric(mn.name)) {
       return mn.name;
     }
-    var t = this.traits.getTrait(mn);
+    var t = this.traits.getTrait(mn, -1);
     if (t) {
       return t.getName().getMangledName();
     }
@@ -376,7 +376,7 @@ module Shumway.AVMX {
     if (mn.isRuntimeName() && isNumeric(mn.name)) {
       return this.value[mn.name];
     }
-    var t = this.traits.getTrait(mn);
+    var t = this.traits.getTrait(mn, -1);
     if (t) {
       return this[t.getName().getMangledName()];
     }
@@ -387,7 +387,7 @@ module Shumway.AVMX {
     if (mn.isRuntimeName() && isNumeric(mn.name)) {
       this.value[mn.name] = value;
     }
-    var t = this.traits.getTrait(mn);
+    var t = this.traits.getTrait(mn, -1);
     if (t) {
       this[t.getName().getMangledName()] = value;
       return;

--- a/src/avm2/run.ts
+++ b/src/avm2/run.ts
@@ -357,7 +357,6 @@ module Shumway.AVMX {
     return delete this[mn.getPublicMangledName()];
   }
 
-
   function axCallProperty(mn: Multiname, args: any []): any {
     return this[this.axResolveMultiname(mn)].axApply(this, args);
   }
@@ -406,19 +405,11 @@ module Shumway.AVMX {
     return delete this[mn.getPublicMangledName()];
   }
 
-  function axFunctionApply(self: any, args?: any): any {
-    return this.value.apply(self, args);
-  }
-
   function axFunctionConstruct() {
     release || assert(this.prototype);
     var object = Object.create(this.prototype);
     this.value.apply(object, arguments);
     return object;
-  }
-
-  function axFunctionCall(self: any, ...args: any[]): any {
-    return this.value.apply(self, args);
   }
 
   export function axSetPublicProperty(nm: any, value: any) {
@@ -1014,8 +1005,8 @@ module Shumway.AVMX {
 
       var AXFunction = this.prepareNativeClass("AXFunction", "Function", false);
       D(AXFunction, "axBox", axBoxPrimitive);
-      D(AXFunction.dPrototype, "axCall", axFunctionCall);
-      D(AXFunction.dPrototype, "axApply", axFunctionApply);
+      D(AXFunction.dPrototype, "axCall", AS.ASFunction.prototype.call);
+      D(AXFunction.dPrototype, "axApply", AS.ASFunction.prototype.apply);
       D(AXFunction.tPrototype, '$BgtoString', AXFunction.axBox(function () {
         return "[Function Object]";
       }));


### PR DESCRIPTION
This aligns our parsing and interpretation of namespaces quite closely with Tamarin's. I regressed the one passing test for `protected`, but know how to fix that, too. Just want to get this in.